### PR TITLE
volumes made windows compatible as driver on Windows does not support…

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,7 @@ services:
     networks:
       - net     
     volumes:
-      - jupyter_notebooks:/opt   
+      - ./notebooks:/opt
 
 
   nbviewer:
@@ -37,14 +37,6 @@ services:
       - net
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
-
-volumes:
-  jupyter_notebooks:
-    driver_opts:
-      type: none
-      device: $PWD/notebooks
-      o: bind
-
 
 networks:
   net:


### PR DESCRIPTION
… any options

Made these changes as the built-in local driver on Windows does not support any options.
Refer https://docs.docker.com/engine/reference/commandline/volume_create/#driver-specific-options

Tested in mac and windows